### PR TITLE
Fixed get_ten_day_avg_daily_volume() and removed get_three_month_avg_daily_volume() 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,3 +46,6 @@
 1.13  02/14/2023 -- Implemented fixes for #132 and #128 by refactoring package to use Yahoo API instead of scraping.
 1.13  02/14/2023 -- Added method to retrieve ESG data as requested in #48.
 1.13  02/14/2023 -- Added additional unit tests.
+1.14  02/21/2023 -- Fixed get_ten_day_avg_daily_volume as reported in #137.
+1.14  02/21/2023 -- Removed get_three_month_avg_daily_volume due to value now missing in Yahoo data.
+1.14  02/21/2023 -- Added unit test for get_ten_day_avg_daily_volume

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ A python module that returns stock, cryptocurrency, forex, mutual fund, commodit
 .. image:: https://static.pepy.tech/badge/yahoofinancials/week
     :target: https://pepy.tech/project/yahoofinancials
 
-Current Version: v1.13
+Current Version: v1.14
 
-Version Released: 02/14/2023
+Version Released: 02/21/2023
 
 Report any bugs by opening an issue here: https://github.com/JECSand/yahoofinancials/issues
 
@@ -145,7 +145,6 @@ Additional Module Methods
 - get_prev_close_price()
 - get_open_price()
 - get_ten_day_avg_daily_volume()
-- get_three_month_avg_daily_volume()
 - get_stock_exchange()
 - get_market_cap()
 - get_daily_low()

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ A powerful financial data module used for pulling both fundamental and technical
 Installation
 -------------
 - yahoofinancials runs on Python 3.6, 3.7, 3.8, 3.9, 3.10, and 3.11.
-- This package depends on beautifulsoup4, pytz, requests, and cryptography to work.
+- This package depends on pytz & requests to work.
 
 1. Installation using pip:
 

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name='yahoofinancials',
-    version='1.13',
+    version='1.14',
     description='A powerful financial data module used for pulling both fundamental and technical data from Yahoo Finance',
     long_description=long_description,
     url='https://github.com/JECSand/yahoofinancials',
-    download_url='https://github.com/JECSand/yahoofinancials/archive/1.13.tar.gz',
+    download_url='https://github.com/JECSand/yahoofinancials/archive/1.14.tar.gz',
     author='Connor Sanders',
     author_email='connor@exceleri.com',
     license='MIT',

--- a/test/test_yahoofinancials.py
+++ b/test/test_yahoofinancials.py
@@ -1,5 +1,5 @@
-# YahooFinancials Unit Tests v1.13
-# Version Released: 02/14/2023
+# YahooFinancials Unit Tests v1.14
+# Version Released: 02/21/2023
 # Author: Connor Sanders
 # Tested on Python 3.6, 3.7, 3.8, 3.9, 3.10, and 3.11
 # Copyright (c) 2023 Connor Sanders
@@ -95,6 +95,13 @@ class TestModule(TestCase):
 
     # Extra Module Methods Test
     def test_yf_module_methods(self):
+
+        # 10 Day Average Daily Volume
+        if isinstance(self.test_yf_stock_single.get_ten_day_avg_daily_volume(), int):
+            self.assertEqual(True, True)
+        else:
+            self.assertEqual(False, True)
+        
         # Stock Current Price
         if isinstance(self.test_yf_stock_single.get_current_price(), float):
             self.assertEqual(True, True)

--- a/yahoofinancials/yf.py
+++ b/yahoofinancials/yf.py
@@ -1,12 +1,12 @@
 """
 ==============================
 The Yahoo Financials Module
-Version: 1.13
+Version: 1.14
 ==============================
 
 Author: Connor Sanders
 Email: sandersconnor1@gmail.com
-Version Released: 02/14/2023
+Version Released: 02/21/2023
 Tested on Python 3.6, 3.7, 3.8, 3.9, 3.10, and 3.11
 
 Copyright (c) 2023 Connor Sanders
@@ -44,7 +44,7 @@ historical_prices = yahoo_financials.get_historical_price_data('2015-01-15', '20
 from yahoofinancials.calcs import num_shares_outstanding, eps
 from yahoofinancials.etl import YahooFinanceETL
 
-__version__ = "1.13"
+__version__ = "1.14"
 __author__ = "Connor Sanders"
 
 
@@ -241,10 +241,7 @@ class YahooFinancials(YahooFinanceETL):
         return self._stock_price_data('regularMarketOpen')
 
     def get_ten_day_avg_daily_volume(self):
-        return self._stock_price_data('averageDailyVolume10Day')
-
-    def get_three_month_avg_daily_volume(self):
-        return self._stock_price_data('averageDailyVolume3Month')
+        return self._stock_summary_data('averageDailyVolume10Day')
 
     def get_stock_exchange(self):
         return self._stock_price_data('exchangeName')


### PR DESCRIPTION
_get_ten_day_avg_daily_volume()_ was fixed using summary details data. On the other hand _get_three_month_avg_daily_volume()_ was removed due to Yahoo no longer returning that data. Code test coverage was also expanded. This PR addresses #137.