### PR TITLE
Do not retry requests in case of response with 4xx status code 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,3 +49,4 @@
 1.14  02/21/2023 -- Fixed get_ten_day_avg_daily_volume as reported in #137.
 1.14  02/21/2023 -- Removed get_three_month_avg_daily_volume due to value now missing in Yahoo data.
 1.14  02/21/2023 -- Added unit test for get_ten_day_avg_daily_volume
+1.15  04/30/2023 -- Don't retry requests if response code is a client error (4xx). 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name='yahoofinancials',
-    version='1.14',
+    version='1.15',
     description='A powerful financial data module used for pulling both fundamental and technical data from Yahoo Finance',
     long_description=long_description,
     url='https://github.com/JECSand/yahoofinancials',


### PR DESCRIPTION
While using the library to process a batch of tickers I noticed that fetching data synchronously caught 404 exceptions and kept processing tickers, while running in concurrent mode didn't. 

Digging into the code a bit I also noticed that retries were set to happen for any status code that isn't 200. Since 404 responses always lead to the same outcome the library ends up trying the requests 10 times, sleeping 20 to 40 seconds in between each try, slowing everything right down. 

So ended up 
- Refactoring `YahooFinanceETL#get_stock_data` to align behavior between concurrent and non concurrent modes - concurrent mode now logs a warning and keeps going instead of breaking.
- Refactoring `YahooFinanceETL#_request_handler` to avoid retrying for any `4xx` status code. This led to a big speed bump for processing my data set. (which resulted in a fair amount of 404s)